### PR TITLE
update for tifffile>=2022.7.28

### DIFF
--- a/python/cucim/requirements-test.txt
+++ b/python/cucim/requirements-test.txt
@@ -5,4 +5,4 @@ psutil>=5.8.0
 pytest>=6.2.4
 pytest-cov>=2.12.1
 pytest-lazy-fixture>=0.6.3
-tifffile>=2021.7.2
+tifffile>=2022.7.28

--- a/python/cucim/tests/util/gen_image.py
+++ b/python/cucim/tests/util/gen_image.py
@@ -16,6 +16,7 @@
 import argparse
 import logging
 import os
+import tifffile
 
 try:
     from .gen_tiff import TiffGenerator
@@ -79,7 +80,13 @@ class ImageGenerator:
                     + f' compression={compression}, resolution={resolution}].')
 
             file_name = f'{kind}_{pattern}_{image_size_str}_{tile_size}'
-
+            if resolution is None or len(resolution) == 2:
+                unit = None
+            elif len(resolution) == 3:
+                unit = resolution[2]
+                resolution = resolution[:2]
+            if unit is None:
+                unit = tifffile.RESUNIT.NONE
             image_path = generator_obj.save_image(image_data,
                                                   dest_folder,
                                                   file_name=file_name,
@@ -89,7 +96,8 @@ class ImageGenerator:
                                                   image_size=image_size,
                                                   tile_size=tile_size,
                                                   compression=compression,
-                                                  resolution=resolution)
+                                                  resolution=resolution,
+                                                  resolutionunit=unit)
             self.logger.info('  Generated %s...', image_path)
             results.append(image_path)
 

--- a/python/cucim/tests/util/gen_tiff.py
+++ b/python/cucim/tests/util/gen_tiff.py
@@ -38,7 +38,8 @@ class TiffGenerator:
         return None
 
     def save_image(self, image_data, dest_folder, file_name, kind, subpath,
-                   pattern, image_size, tile_size, compression, resolution):
+                   pattern, image_size, tile_size, compression, resolution,
+                   resolutionunit):
         # You can add pyramid images (0: largest resolution)
         if isinstance(image_data, list):
             arr_stack = image_data
@@ -62,8 +63,7 @@ class TiffGenerator:
 
                 if resolution:
                     level_resolution = (resolution[0] / (level + 1),
-                                        resolution[1] / (level + 1),
-                                        resolution[2])
+                                        resolution[1] / (level + 1))
 
                 tif.write(
                     src_arr,
@@ -75,6 +75,7 @@ class TiffGenerator:
                     compression=compression,  # requires imagecodecs
                     subfiletype=1 if level else 0,
                     resolution=level_resolution,
+                    resolutionunit=resolutionunit,
                 )
         return tiff_file_name
 


### PR DESCRIPTION
Adapts the resolution unit tests to work with the newer-style tifffile arguments.